### PR TITLE
Adjust FROM AS case mismatch (#8)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20 as builder
+FROM golang:1.20 AS builder
 
 WORKDIR /app
 COPY . .


### PR DESCRIPTION
As described in #8 this PR will adjust the case in line 1 of the dockerfile to prevent warnings occurring during the docker file generation.