### PR TITLE
Output diff indent by 2 spaces #21

### DIFF
--- a/model/rockon.go
+++ b/model/rockon.go
@@ -14,7 +14,7 @@ func (r RockOn) ToJSON() (string, error) {
 	var tmp strings.Builder
 	enc := json.NewEncoder(&tmp)
 	enc.SetEscapeHTML(false)
-	enc.SetIndent("", "    ")
+	enc.SetIndent("", "  ")
 
 	err := enc.Encode(r)
 	if err != nil {


### PR DESCRIPTION
When re-encoding the RockOn type via the ToJSON function, indent by 2 spaces; was 4 spaces.

Fixes #21 