### PR TITLE
rm architecture reference, add static binary build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY . .
 
 RUN go mod download
 
-RUN GOOS=linux GOARCH=amd64 go build -ldflags="-w -s"
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s"
 
 FROM scratch
 


### PR DESCRIPTION
Fixes #30.

Removing the architecture reference and adding the setting to force a static binary build seems to work. I finally figured out how to install a `aarch64` VM using virt and did a test run there. The screenshot seems to show now the appropriate output (sorry, I couldn't get the guest --> host copy/past to work yet, missing something there):

<img width="754" height="352" alt="image" src="https://github.com/user-attachments/assets/8ff966ff-ec7b-4a43-bab6-e6a93c925fd3" />
