### PR TITLE
Indicate non-existent file #33

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ N.B. uses a `go install` instantiated binary; see [Development](#development) be
 ~/go/bin/rockon-validator --check forgejo-runner.json
 ```
 
-Returns `0` (success), or `1` (fail).
+Returns `0` (success), `1` (fail), and `2` (No matching files found.). 
 
 Similarly, `--diff` produces a `diffutils` formated output re: existing and proposed file format:
 
@@ -110,13 +110,27 @@ An alternative target index file can be passed via the `--root` flag.
 
 ## Development
 
-Details more associated with development. 
+Details more associated with development.
 
 ### GO download and install
 
-Alternative to the `docker run` approach, and required for development purposes.
+Alternatives to the `docker run` approach, and required for development purposes.
 Requires GO version 1.20 or later.
 - [Upstream install instructions](https://go.dev/doc/install)
+
+### Go build
+
+Creates a `rockon-validator` binary directly in/from the source root:
+
+```shell
+go build
+```
+
+Run via:
+
+```shell
+./rockon-validator
+````
 
 ### Script install/run (from repo)
 

--- a/main.go
+++ b/main.go
@@ -64,6 +64,10 @@ func parseFlags() {
 func parseFileArgs() (filePaths []string) {
 	for _, f := range flag.Args() {
 		glob, _ := filepath.Glob(f)
+		if glob == nil {
+			logger.Error("No matching files found.")
+			os.Exit(2)
+		}
 		filePaths = append(filePaths, glob...)
 	}
 


### PR DESCRIPTION
Extend parseFileArgs() using filepath.Glob (std library), to error log "No matching files found." with rc=2.

Update README.md with new return error code, and examples of `go build` and binary execution in/from source tree. N.B. a binary build is required to test shell return codes.

Fixes #33 

---

See: https://pkg.go.dev/path/filepath#Glob for upstream docs on filepath.Glob, which returns nil when no matches were found.