### PR TITLE
Add .gitignore #36

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/rockon-validator


### PR DESCRIPTION
Avoid inadvertent inclusion of an in-source-tree `go build` artefact.

Fixes #36 

