### PR TITLE
root.json treatment and sorting #11

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,14 @@ N.B. uses a `go install` instantiated binary; see [Development](#development) be
 ```
 
 Returns:
-- `0` success: file is valid; or `--diff` to valid status was achieved.   
-- `1` failed validation.
+- `0` Success: file is valid; or `--diff` to valid status was achieved.   
+- `1` Failed validation.
 - `2` No matching files found.
-- `3` Invalid JSON format file=./path/not-json.json
-- `4` No matching index file: defaults to root.json (same path as tested definition)
-- `5` Invalid JSON format in index file=./path/root.json
+- `3` Invalid JSON format file=./path/not-json.json.
+- `4` No matching index file: defaults to root.json (same path as tested definition).
+- `5` Invalid JSON format in index file=./path/root.json.
+- `6` Overwrite Rockon file error.
+- `7` Overwire/write index file error.
 
 Similarly, `--diff` produces a `diffutils` formated output re: existing and proposed file format:
 
@@ -146,7 +148,7 @@ Details more associated with development.
 ### GO download and install
 
 Alternatives to the `docker run` approach, and required for development purposes.
-Requires GO version 1.20 or later.
+Requires GO version 1.23 or later.
 - [Upstream install instructions](https://go.dev/doc/install)
 
 ### Go build

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rockstor/rockon-validator
 
-go 1.20
+go 1.23
 
 require (
 	github.com/hexops/gotextdiff v1.0.3

--- a/main.go
+++ b/main.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"golang.org/x/exp/slog" // nee "log/slog"
@@ -37,6 +39,8 @@ Options:
 var (
 	checkFlag, diffFlag, writeFlag, verboseFlag, debugFlag bool
 	rootFlag, rootFile                                     string
+	indexOrigContent                                       string
+	fileInfo                                               os.FileInfo
 	logger                                                 *slog.Logger
 )
 
@@ -62,7 +66,6 @@ func parseFlags() {
 }
 
 func parseFileArgs() (filePaths []string) {
-	logger.Debug("parseFileArgs()", slog.Any("called with", filePaths))
 	for _, f := range flag.Args() {
 		glob, _ := filepath.Glob(f)
 		if glob == nil {
@@ -71,7 +74,7 @@ func parseFileArgs() (filePaths []string) {
 		}
 		filePaths = append(filePaths, glob...)
 	}
-	// recurse sub-directories
+	// recurse subdirectories
 	//for i, f := range filePaths {
 	//	files, err := os.ReadDir(f)
 	//	if err != nil {
@@ -107,32 +110,41 @@ func setupLogger(logLevel *slog.LevelVar) *slog.Logger {
 		},
 	}
 	logHandler := tint.NewHandler(os.Stderr, logOpts)
-	logger := slog.New(logHandler)
+	logger = slog.New(logHandler)
 	slog.SetDefault(logger)
 	return logger
 }
 
 func checkRootMap(rootMap map[string]string, filename string, rockon model.RockOn) {
-	var filenameFound bool
-	var keyName string
+	filenameFound, keyName := false, ""
 	// Index file key expected to match lowercase Rockon name.
-	for key := range rootMap {
-		filenameFound = rootMap[key] == filename
+	for key, value := range maps.All(rootMap) {
+		filenameFound = value == filename
 		if filenameFound {
 			keyName = key
 			break
 		}
 	}
-	for name := range rockon {
-		if filenameFound {
-			if name != keyName {
-				slog.Warn("RockOn name does not match", slog.String("root.json", keyName), slog.String("rockon", name), slog.String("file", filepath.Base(filename)))
-			}
-		} else {
-			rootMap[name] = filename
-			logger.Debug("root.json map", slog.Any("rootMap", rootMap))
+
+	// maps.keys(rockon) returns an iterator over our single entry Rockon map.
+	// slices.Collect enables retrieval of key by index on slice.
+	// https://pkg.go.dev/iter#hdr-Standard_Library_Usage
+	var rockonTitle = slices.Collect(maps.Keys(rockon))[0]
+	var lowerCaseName = strings.ToLower(rockonTitle)
+	if filenameFound {
+		if lowerCaseName != keyName {
+			slog.Info("Found match in index for", slog.String("filename", filename))
+			slog.Warn("Name mismatch:", slog.String("index", keyName), slog.String("expected", lowerCaseName), slog.String("file", filepath.Base(filename)))
+			slog.Warn("(if --write) Removing and adding expected entry.")
+			delete(rootMap, keyName)
 		}
+	} else {
+		slog.Warn("No match in index for", slog.String("filename", filename))
+		slog.Info("(if --write) Adding entry", slog.String("index", lowerCaseName), slog.String("filename", filename))
 	}
+	rootMap[lowerCaseName] = filename
+	logger.Debug("root.json map", slog.Any("rootMap", rootMap))
+
 }
 
 func main() {
@@ -162,106 +174,158 @@ func main() {
 	logger.Debug("Verbosity flags", slog.Bool("verboseFlag", verboseFlag), slog.Bool("debugFlag", debugFlag))
 	logger.Debug("root.json flags", slog.String("rootFlag", rootFlag), slog.String("rootFile", rootFile))
 
-	var numDiffFiles int
+	rootFile = rootFlag
+
+	diffToValid := false
+	indexValidated := false
+	var indexValidatedJSONBArray []byte
+	// Working map for index file entries.
+	var rootMap = make(map[string]string)
+
 	for _, fileName := range parseFileArgs() {
 		logger.Info("Checking", slog.String("file", fileName))
-		data, err := os.ReadFile(fileName)
+		fileData, err := os.ReadFile(fileName)
 		if err != nil {
 			logger.Error("Reading file", slog.String("file", fileName), slog.Any("err", err))
 			os.Exit(1) // We should be able to read all the files
 		}
-		dataString := string(data)
+		// Loop local re-declared variable
+		origFileContent := string(fileData)
 
-		if !json.Valid(data) {
+		if !json.Valid(fileData) {
 			logger.Error("Invalid JSON format", slog.String("file", fileName))
 			os.Exit(3) // All files should at least parse as JSON.
 		}
 
-		rootFile = rootFlag
-		if rootFlag == "" {
-			rootFile = filepath.Join(filepath.Dir(fileName), "root.json")
-			logger.Info("Using same-path index", slog.String("file", rootFile))
-		} else {
-			logger.Info("Using passed index", slog.String("file", rootFile))
+		// Enables same-dir index default via: filepath.Dir(fileName)
+		// Avoid reprocessing index on every Rockon definition validation
+		// Optimise: we may already have just read, and JSON Validated our index file.
+		if indexValidated == false {
+			if rootFlag == "" {
+				rootFile = filepath.Join(filepath.Dir(fileName), "root.json")
+				logger.Info("Using same-path index", slog.String("file", rootFile))
+			} else {
+				logger.Info("Using passed index", slog.String("file", rootFile))
+			}
+
+			rootData, rootReadErr := os.ReadFile(rootFile)
+			// TODO: Warn on no index when using '--check' as this can create an index file from the passed definitions.
+			//  Set flag on --check and no index file found to avoid further references.
+			if rootReadErr != nil {
+				logger.Error("Reading index", slog.String("file", rootFile), slog.Any("rootReadErr", rootReadErr))
+				os.Exit(4)
+			}
+			if !json.Valid(rootData) {
+				logger.Error("Invalid JSON format in index", slog.String("file", rootFile))
+				os.Exit(5) // All files should at least parse as JSON.
+			}
+
+			// Stash Original index file content.
+			indexOrigContent = string(rootData)
+
+			rootValidErr := json.Unmarshal(rootData, &rootMap)
+			logger.Debug("root.json flags", slog.String("rootFlag", rootFlag), slog.String("rootFile", rootFile))
+			if rootValidErr != nil {
+				logger.Error("Index validation failed for", slog.String("file", rootFile))
+				os.Exit(1)
+			}
+			indexValidated = true
 		}
 
-		rootData, err := os.ReadFile(rootFile)
-		if err != nil {
-			logger.Error("Reading index", slog.String("file", rootFile), slog.Any("err", err))
-			os.Exit(4)
-		}
-		if !json.Valid(rootData) {
-			logger.Error("Invalid JSON format in index", slog.String("file", rootFile))
-			os.Exit(5) // All files should at least parse as JSON.
-		}
-
-		// We re-validate our rootData on every parseFileArgs() entry
-		// Likely associated with multiple embedded rockon repos, each with possibly their own index file.
-		rootMap := map[string]string{}
-		err = json.Unmarshal(rootData, &rootMap)
-		logger.Debug("root.json flags", slog.String("rootFlag", rootFlag), slog.String("rootFile", rootFile))
-		if err != nil {
-			logger.Error("Index validation failed for", slog.String("file", rootFile))
-			os.Exit(1)
-		}
-
-		// Validate Rockon file data against RockOn model, confirming matching index entry (root.json).
-		// But only:
-		if fileName != rootFile {
-			var rockon model.RockOn
-			err = json.Unmarshal(data, &rockon)
-			if err != nil {
-				if filepath.Ext(fileName) == ".json" {
-					logger.Error("Unmarshaling json data", slog.String("file", fileName), slog.Any("err", err))
-					os.Exit(1) // File was named `*.json`, but couldn't be marshalled as expected, so we need to exit.
-				}
-				logger.Warn("Non *.json filename passed as input, skipping", slog.String("file", fileName))
-				continue // File was not named `*.json`, so we shouldn't worry about it.
-			}
-
-			checkRootMap(rootMap, filepath.Base(fileName), rockon)
-
-			result, err := rockon.ToJSON()
-			if err != nil {
-				logger.Error("Marshaling to JSON", slog.Any("err", err))
-				os.Exit(1) // This should basically never happen
-			}
-
-			if dataString != result {
-				numDiffFiles++
-			}
-
-			if diffFlag {
-				aPath := "a/" + strings.TrimPrefix(fileName, "/")
-				bPath := "b/" + strings.TrimPrefix(fileName, "/")
-				edits := myers.ComputeEdits(span.URIFromPath(aPath), dataString, result)
-				fmt.Println(gotextdiff.ToUnified(aPath, bPath, dataString, edits))
-			}
-
-			if writeFlag {
-				stat, _ := os.Stat(fileName)
-				logger.Debug("Writing rockon", slog.String("file", fileName))
-				err = os.WriteFile(fileName, []byte(result), stat.Mode())
-				if err != nil {
-					logger.Error("Writing rockon", slog.String("file", fileName), slog.Any("err", err))
-				}
-				rootStat, err := os.Stat(rootFile)
-				if os.IsNotExist(err) {
-					rootStat = stat
-				}
-				rootJson, _ := json.MarshalIndent(rootMap, "", "  ")
-				logger.Debug("Writing root", slog.String("file", rootFile))
-				err = os.WriteFile(rootFile, rootJson, rootStat.Mode())
-				if err != nil {
-					logger.Error("Writing root", slog.String("file", rootFile), slog.Any("err", err))
-				}
-			}
-		} else {
+		// Skip Rockon validation for index file: validated above.
+		if filepath.Clean(fileName) == filepath.Clean(rootFile) {
 			logger.Warn("Skipped RockOn validation for index", slog.String("file", rootFile))
+			continue
+		}
+
+		// Validate Rockon file fileData against RockOn model, confirming matching index entry (root.json).
+		var rockon model.RockOn
+		rockonValidErr := json.Unmarshal(fileData, &rockon)
+		if rockonValidErr != nil {
+			if filepath.Ext(fileName) == ".json" {
+				logger.Error("Unmarshalling json fileData", slog.String("file", fileName), slog.Any("err", rockonValidErr))
+				os.Exit(1) // File was named `*.json`, but couldn't be marshalled as expected, so we need to exit.
+			}
+			logger.Warn("Non *.json filename passed as input, skipping", slog.String("file", fileName))
+			continue // File was not named `*.json`, so we shouldn't worry about it.
+		}
+
+		// Check and update rootMap from index file against this Rock-on's filename and title.
+		checkRootMap(rootMap, filepath.Base(fileName), rockon)
+
+		rockonValidatedJSON, rockonToJsonErr := rockon.ToJSON()
+		if rockonToJsonErr != nil {
+			logger.Error("Marshaling to JSON", slog.Any("err", rockonToJsonErr))
+			os.Exit(1) // This should basically never happen
+		}
+
+		if origFileContent != rockonValidatedJSON {
+			diffToValid = true
+		}
+
+		// Print diff for this Rockon.
+		if diffFlag {
+			aPath := "a/" + strings.TrimPrefix(fileName, "/")
+			bPath := "b/" + strings.TrimPrefix(fileName, "/")
+			edits := myers.ComputeEdits(span.URIFromPath(aPath), origFileContent, rockonValidatedJSON)
+			fmt.Println(gotextdiff.ToUnified(aPath, bPath, origFileContent, edits))
+		}
+
+		// Get existing FileInfo from local variable to reuse in os.WriteFile overwrite.
+		fileInfo, _ = os.Stat(fileName)
+
+		if writeFlag { // this rockon
+			logger.Debug("Overwriting rockon", slog.String("file", fileName))
+			err = os.WriteFile(fileName, []byte(rockonValidatedJSON), fileInfo.Mode())
+			if err != nil {
+				logger.Error("Overwriting rockon", slog.String("file", fileName), slog.Any("err", err))
+				os.Exit(6)
+			}
+
+		}
+	} // fileName in parseFileArgs()
+
+	// Remaining index file treatment/feedback:
+
+	// Slice.sorted of index file names GO 1.23 onwards
+	// https://www.dolthub.com/blog/2024-12-20-collection-functions-in-go-1-23/#sorting-map-elements
+	// Strings in GO are read-only slices of bytes.
+	// sortedKeys := slices.Sorted(maps.Keys(rootMap))
+	// logger.Info("Sorted index", slog.Any("Keys", sortedKeys))
+
+	// From: https://go.dev/src/encoding/json/encode.go
+	// "The map keys are sorted and used as JSON object keys ..."
+	// Works when arbitrary index file elements (Rockon Titles) are all lower-case.
+	indexValidatedJSONBArray, _ = json.MarshalIndent(rootMap, "", "  ")
+
+	if writeFlag { // index file
+		rootStat, rootStatErr := os.Stat(rootFile)
+		// if no index file for fileInfo, use last Rockon FileInfo
+		if os.IsNotExist(rootStatErr) {
+			rootStat = fileInfo
+		}
+		logger.Debug("Overwriting index", slog.String("file", rootFile))
+		indexOverwriteErr := os.WriteFile(rootFile, indexValidatedJSONBArray, rootStat.Mode())
+		if indexOverwriteErr != nil {
+			logger.Error("Overwriting index", slog.String("file", rootFile), slog.Any("err", indexOverwriteErr))
+			os.Exit(7)
 		}
 	}
 
-	if checkFlag {
-		os.Exit(numDiffFiles)
+	// Print diff for the index file.
+	if diffFlag {
+		aPath := "a/" + strings.TrimPrefix(rootFile, "/")
+		bPath := "b/" + strings.TrimPrefix(rootFile, "/")
+		edits := myers.ComputeEdits(span.URIFromPath(aPath), indexOrigContent, string(indexValidatedJSONBArray))
+		fmt.Println(gotextdiff.ToUnified(aPath, bPath, indexOrigContent, edits))
+	}
+
+	// Return 0 when --diff and diff to valid successfully generated.
+	if diffToValid {
+		if diffFlag {
+			os.Exit(0)
+		} else {
+			os.Exit(1)
+		}
 	}
 }


### PR DESCRIPTION
- Avoid re-validating index for every rockon definition.
- Avoid writing/re-writing proposed index file for every rockon processed.
- Provide patch to compliance (--diff) on index file after doing the same for all rockons passed.
- Reduce complexity via explicit continue on index, avoiding unnecessary if/else.
- Ensure clean path on index file match.
- Various comment, TODO, and logging changes.
- Variable name refactoring for clarity.
- Additional 'Overwrite' error return codes.
- Explicit --diff flag success via rc=0.
- Remove inadvertent local variable shadows.
- Remove excessive re-use or `err` local variable.
- More normalising on var type declares when initial value is irrelevant, favouring short := declaration for
explicit initial values, and multiple diss-similar type declarations.
- Add comment link to upstream Marshall sort behaviour.
- Update GO minimum version to v1.23.

Fixes #11 

---

This PR predominantly continues general development around refining of index file treatment. In large part the sighted issue is addressed by our move to removing case from the index file all-together. Where these changes help to maintain this new norm (See: https://github.com/rockstor/rockon-registry/issues/465) and can, via updated capability, warn and provide --diff and --write output to advise and establish this new norm.