### PR TITLE
Update docker image base re GO 1.23 #46

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20 AS builder
+FROM golang:1.25.1 AS builder
 
 WORKDIR /app
 COPY . .


### PR DESCRIPTION
Having recently moved to a GO 1.23 min, update
the Dockerfile FROM directive from 1.20 to the
latest 1.25.1 counterpart.

Fixes #46