### PR TITLE
Revise treatment of "ui" element #56

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ a failed validation (rc=1) error is returned.
 
 ### Omitted entries
 
-Many json Rock-on definition elements are optional: e.g. `icon`, `more_info`, `devices` etc.
+Many JSON Rock-on definition elements are optional: e.g. `icon`, `more_info`, `devices`, `ui` etc.
 Where-as in a GO `struct`, our backing validation, all possible fields are defined.
-To handle this miss-match the [omitempty](https://www.sohamkamani.com/golang/omitempty/) json tag is used.
-This effectively ignores/removes empty, default, or missing json elements during Un/marshalling from/to JSON string format.
+To handle this miss-match the [omitempty](https://www.sohamkamani.com/golang/omitempty/) JSON tag is used.
+This effectively ignores/removes empty, default, or missing JSON elements during Un/marshalling from/to JSON string format.
 
 For the more advanced `--diff` and `--write` options, this can have surprising consequences.
 I.e. if we want to maintain an explicit `"uid:" 0` element, which would otherwise be removed as a default int32 value,
-we can instead use a pointer to int32, default is undefined: ergo no json element no json marshalling (struct to json).
+we can instead use a pointer to int32, default is undefined: ergo no JSON element no JSON marshalling (struct to JSON).
 Embedded struct pointers, and custom variable types can also approach this same problem re `omitemtpy` compliance.
 All of the above approaches are used within this project.
 

--- a/model/rockon.go
+++ b/model/rockon.go
@@ -41,10 +41,12 @@ type RockonDetails struct {
 }
 
 type UISlug struct {
-	Https bool   `json:"https,omitempty"` // Whether the UI can be accessed over https://
-	Slug  string `json:"slug,omitempty"`  // link to webui becomes ROCKSTOR_IP:PORT/gui with slug value gui
+	Https bool   `json:"https,omitempty"` // Whether the UI can be accessed over https://. Optional element.
+	Slug  string `json:"slug"`            // Web-UI path: ROCKSTOR_IP:PORT/gui with slug value "gui". Required element.
 }
 
+// MarshalJSON override (built-in), if contents are default (for type) (Https=false, Slug=""),
+// remove the RockonDetails.UI entry via nil assignment, and normally Marshal there-after.
 func (r RockonDetails) MarshalJSON() ([]byte, error) {
 	type ro RockonDetails
 	if r.UI != nil && *r.UI == (UISlug{}) {


### PR DESCRIPTION
Establish "slug" child of "ui" top-level element as required. I.e. remove `omitempty` json tag used to inform GO struct to JSON marshalling on default for type (string so "") instances. This avoids single "https" child entries where it, a boolean, is non-default (true) when slug is default.

Includes:
- Related minor code comment improvements.
- Minor README.md "json" to "JSON" corrections.

Fixes #56 